### PR TITLE
Add extra nix.conf to consider using cachix in flake

### DIFF
--- a/images/ubuntu-nix-sudoer/Containerfile
+++ b/images/ubuntu-nix-sudoer/Containerfile
@@ -26,6 +26,7 @@ ENV USER=$username
 
 RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
   --extra-conf "sandbox = false" \
+  --extra-conf "accept-flake-config = true" \
   --init none \
   --no-confirm
 

--- a/images/ubuntu-nix-systemd/Containerfile
+++ b/images/ubuntu-nix-systemd/Containerfile
@@ -17,6 +17,8 @@ ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 
 RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
   --extra-conf "sandbox = false" \
+  --extra-conf "trusted-users = root user" \
+  --extra-conf "accept-flake-config = true" \
   --no-start-daemon \
   --no-confirm
 


### PR DESCRIPTION
Merging https://github.com/kachick/dotfiles/pull/1235 made much slow to build container in the CI.(8 minutes -> 60 or more minutes)
In my understanding, the container flake definition does not require cachix, however results time-out.
I'm guessing, it came from the specified substituters in flake.nix confirmation in the steps.
If then, I should add extra conf likely https://github.com/kachick/dotfiles/commit/ee8a24d1077e7cd22c772d415ae93230fc7821f9

ref: https://github.com/kachick/dotfiles/issues/754
